### PR TITLE
ENH: Add support for resetting windows/level

### DIFF
--- a/Modules/Scripted/QReads/QReads.py
+++ b/Modules/Scripted/QReads/QReads.py
@@ -115,6 +115,7 @@ class QReadsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.SlabThicknessSliderWidget.connect("valueChanged(double)", self.updateParameterNodeFromGUI)
     self.ui.InverseGrayButton.connect("clicked(bool)", self.updateParameterNodeFromGUI)
     self.ui.EnableWLButton.connect("clicked(bool)", self.updateParameterNodeFromGUI)
+    self.ui.ResetWLButton.connect("clicked()", QReadsLogic.resetWindowLevel)
 
     # Install event filters
     slicer.util.mainWindow().installEventFilter(self._closeApplicationEventFilter)
@@ -566,6 +567,11 @@ class QReadsLogic(ScriptedLoadableModuleLogic):
 
         volumeDisplayNode.SetAutoWindowLevel(0)
         volumeDisplayNode.SetWindowLevel(window, level)
+
+  @staticmethod
+  def resetWindowLevel():
+    for volumeNode in slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode"):
+      volumeNode.GetDisplayNode().AutoWindowLevelOn()
 
   @staticmethod
   def slabModeToString(slabMode):

--- a/Modules/Scripted/QReads/Resources/UI/QReads.ui
+++ b/Modules/Scripted/QReads/Resources/UI/QReads.ui
@@ -386,7 +386,7 @@ QPushButton#ResetWLButton {
         <item row="2" column="2" colspan="2">
          <widget class="QPushButton" name="ResetWLButton">
           <property name="toolTip">
-           <string>Reset the Window/Level to initial DICOM header value</string>
+           <string>Reset window/level to include the entire intensity range (except top/bottom 0.1%, to not let a very thin tail of the intensity distribution to decrease the image contrast too much).</string>
           </property>
           <property name="text">
            <string>Reset</string>


### PR DESCRIPTION
Reset window/level to include the entire intensity range (except top/bottom
0.1%, to not let a very thin tail of the intensity distribution to decrease
the image contrast too much).

Fixes #53