### PR TITLE
BUG: Ensure window geometry and position is restored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/KitwareMedical/Slicer
-    GIT_TAG        b61447b304b1c44f39ecf10b505daba6a9be3b47 # SlicerQReads-v4.13.0-2021-02-04-11cbb38732
+    GIT_TAG        68b5cd0e196c10ab9fbdcaacac38d15f896f18a8 # SlicerQReads-v4.13.0-2021-02-04-11cbb38732
     GIT_PROGRESS   1
     )
 else()

--- a/Modules/Scripted/QReads/QReads.py
+++ b/Modules/Scripted/QReads/QReads.py
@@ -403,12 +403,6 @@ class QReadsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def updateParameterNodeFromVolumeNode(self, volumeNode):
     self._parameterNode.SetParameter("SlabThicknessInMm", str(max(volumeNode.GetSpacing())))
 
-  def onCloseApplicationButton(self):
-    """
-    Close application when user clicks "Close" button.
-    """
-    pass
-
 
 #
 # QReadsLogic

--- a/Modules/Scripted/QReads/QReads.py
+++ b/Modules/Scripted/QReads/QReads.py
@@ -52,6 +52,7 @@ class QReadsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   class CloseApplicationEventFilter(qt.QWidget):
     def eventFilter(self, object, event):
       if event.type() == qt.QEvent.Close:
+        slicer.util.mainWindow().writeSettings()
         event.accept()
         return True
       return False


### PR DESCRIPTION
List of Slicer changes:

```
$ git shortlog b61447b304..68b5cd0e19 --no-merges
Jean-Christophe Fillion-Robin (1):
    [Backport PR-5611] ENH: Add readSettings/writeSetting to qSlicerMainWindow public API
```

Fixes #62