### PR TITLE
ENH: Tweak styling of reset button

### DIFF
--- a/Modules/Scripted/QReads/Resources/UI/QReads.ui
+++ b/Modules/Scripted/QReads/Resources/UI/QReads.ui
@@ -78,10 +78,6 @@ QPushButton#SlabButton:disabled,
 QPushButton#ShowReferenceMarkersButton:disabled,
 QPushButton#ResetReferenceMarkersButton:disabled {
   background-color: rgb(170, 170, 127);
-}
-
-QPushButton#ResetWLButton {
-  background-color: gray;
 }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">


### PR DESCRIPTION
Reset Button too dark. Remove the style sheet command that sets it to gray.