### PR TITLE
BUG: Ensure SlicerQReads resource icons like "Help" are systematically used

### DIFF
--- a/Modules/Scripted/QReads/Resources/QReads.qrc
+++ b/Modules/Scripted/QReads/Resources/QReads.qrc
@@ -7,21 +7,21 @@
 <RCC version="1.0">
 
   <qresource prefix="Icons">
-    <file alias="BrightnessDown.png">Icons/BrightnessDown.png</file>
-    <file alias="BrightnessUp.png">Icons/BrightnessUp.png</file>
-    <file alias="CTBodySoftTissue.png">Icons/CTBodySoftTissue.png</file>
-    <file alias="CTBone.png">Icons/CTBone.png</file>
-    <file alias="CTHead.png">Icons/CTHead.png</file>
-    <file alias="CTLung.png">Icons/CTLung.png</file>
-    <file alias="ContrastDown.png">Icons/ContrastDown.png</file>
-    <file alias="ContrastUp.png">Icons/ContrastUp.png</file>
-    <file alias="DistanceMeasurement.png">Icons/DistanceMeasurement.png</file>
-    <file alias="Help.png">Icons/Help.png</file>
-    <file alias="InverseGray.png">Icons/InverseGray.png</file>
-    <file alias="QREADSImageGroupHeader.png">Icons/QREADSImageGroupHeader.png</file>
-    <file alias="QREADSToolsGroupHeader.png">Icons/QREADSToolsGroupHeader.png</file>
-    <file alias="WL.png">Icons/WL.png</file>
-    <file alias="Zoom.png">Icons/Zoom.png</file>
+    <file alias="SlicerQReads-BrightnessDown.png">Icons/BrightnessDown.png</file>
+    <file alias="SlicerQReads-BrightnessUp.png">Icons/BrightnessUp.png</file>
+    <file alias="SlicerQReads-CTBodySoftTissue.png">Icons/CTBodySoftTissue.png</file>
+    <file alias="SlicerQReads-CTBone.png">Icons/CTBone.png</file>
+    <file alias="SlicerQReads-CTHead.png">Icons/CTHead.png</file>
+    <file alias="SlicerQReads-CTLung.png">Icons/CTLung.png</file>
+    <file alias="SlicerQReads-ContrastDown.png">Icons/ContrastDown.png</file>
+    <file alias="SlicerQReads-ContrastUp.png">Icons/ContrastUp.png</file>
+    <file alias="SlicerQReads-DistanceMeasurement.png">Icons/DistanceMeasurement.png</file>
+    <file alias="SlicerQReads-Help.png">Icons/Help.png</file>
+    <file alias="SlicerQReads-InverseGray.png">Icons/InverseGray.png</file>
+    <file alias="SlicerQReads-QREADSImageGroupHeader.png">Icons/QREADSImageGroupHeader.png</file>
+    <file alias="SlicerQReads-QREADSToolsGroupHeader.png">Icons/QREADSToolsGroupHeader.png</file>
+    <file alias="SlicerQReads-WL.png">Icons/WL.png</file>
+    <file alias="SlicerQReads-Zoom.png">Icons/Zoom.png</file>
   </qresource>
 
 </RCC>

--- a/Modules/Scripted/QReads/Resources/UI/QReads.ui
+++ b/Modules/Scripted/QReads/Resources/UI/QReads.ui
@@ -114,7 +114,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap resource="../QReads.qrc">:/Icons/QREADSImageGroupHeader.png</pixmap>
+         <pixmap resource="../QReads.qrc">:/Icons/SlicerQReads-QREADSImageGroupHeader.png</pixmap>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
@@ -218,7 +218,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/CTLung.png</normaloff>:/Icons/CTLung.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-CTLung.png</normaloff>:/Icons/SlicerQReads-CTLung.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -235,7 +235,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/ContrastDown.png</normaloff>:/Icons/ContrastDown.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-ContrastDown.png</normaloff>:/Icons/SlicerQReads-ContrastDown.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -255,7 +255,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/CTBone.png</normaloff>:/Icons/CTBone.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-CTBone.png</normaloff>:/Icons/SlicerQReads-CTBone.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -275,7 +275,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/CTBodySoftTissue.png</normaloff>:/Icons/CTBodySoftTissue.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-CTBodySoftTissue.png</normaloff>:/Icons/SlicerQReads-CTBodySoftTissue.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -292,7 +292,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/BrightnessUp.png</normaloff>:/Icons/BrightnessUp.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-BrightnessUp.png</normaloff>:/Icons/SlicerQReads-BrightnessUp.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -309,7 +309,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/InverseGray.png</normaloff>:/Icons/InverseGray.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-InverseGray.png</normaloff>:/Icons/SlicerQReads-InverseGray.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -329,7 +329,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/WL.png</normaloff>:/Icons/WL.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-WL.png</normaloff>:/Icons/SlicerQReads-WL.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -352,7 +352,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/CTHead.png</normaloff>:/Icons/CTHead.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-CTHead.png</normaloff>:/Icons/SlicerQReads-CTHead.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -369,7 +369,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/ContrastUp.png</normaloff>:/Icons/ContrastUp.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-ContrastUp.png</normaloff>:/Icons/SlicerQReads-ContrastUp.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -396,7 +396,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
           </property>
           <property name="icon">
            <iconset resource="../QReads.qrc">
-            <normaloff>:/Icons/BrightnessDown.png</normaloff>:/Icons/BrightnessDown.png</iconset>
+            <normaloff>:/Icons/SlicerQReads-BrightnessDown.png</normaloff>:/Icons/SlicerQReads-BrightnessDown.png</iconset>
           </property>
           <property name="iconSize">
            <size>
@@ -416,7 +416,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
            <string/>
           </property>
           <property name="pixmap">
-           <pixmap resource="../QReads.qrc">:/Icons/Zoom.png</pixmap>
+           <pixmap resource="../QReads.qrc">:/Icons/SlicerQReads-Zoom.png</pixmap>
           </property>
          </widget>
         </item>
@@ -465,7 +465,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap resource="../QReads.qrc">:/Icons/QREADSToolsGroupHeader.png</pixmap>
+         <pixmap resource="../QReads.qrc">:/Icons/SlicerQReads-QREADSToolsGroupHeader.png</pixmap>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
@@ -486,7 +486,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
         </property>
         <property name="icon">
          <iconset resource="../QReads.qrc">
-          <normaloff>:/Icons/DistanceMeasurement.png</normaloff>:/Icons/DistanceMeasurement.png</iconset>
+          <normaloff>:/Icons/SlicerQReads-DistanceMeasurement.png</normaloff>:/Icons/SlicerQReads-DistanceMeasurement.png</iconset>
         </property>
         <property name="iconSize">
          <size>
@@ -509,7 +509,7 @@ QPushButton#ResetReferenceMarkersButton:disabled {
      </property>
      <property name="icon">
       <iconset resource="../QReads.qrc">
-       <normaloff>:/Icons/Help.png</normaloff>:/Icons/Help.png</iconset>
+       <normaloff>:/Icons/SlicerQReads-Help.png</normaloff>:/Icons/SlicerQReads-Help.png</iconset>
      </property>
      <property name="iconSize">
       <size>


### PR DESCRIPTION
This commit aliases all resources with the string "SlicerQReads-" and
ensures that SlicerQReads specific resource names are not conflicting with
the one built-in Slicer.

Fixes #85