### PR TITLE
BUG: Update Slicer to include fix related to GDCM predictor6 bug in JPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED slicersources_SOURCE_DIR)
   # Download Slicer sources and set variables slicersources_SOURCE_DIR and slicersources_BINARY_DIR
   FetchContent_Populate(slicersources
     GIT_REPOSITORY git://github.com/KitwareMedical/Slicer
-    GIT_TAG        68b5cd0e196c10ab9fbdcaacac38d15f896f18a8 # SlicerQReads-v4.13.0-2021-02-04-11cbb38732
+    GIT_TAG        0f2d007c19c9306fa6efa5e378786708981c5312 # SlicerQReads-v4.13.0-2021-04-26-d06e71c8a6
     GIT_PROGRESS   1
     )
 else()


### PR DESCRIPTION
See https://discourse.slicer.org/t/slicer-issues-with-displaying-certain-dicom-images/17262?u=spycolyf

Fixes #92

List of Slicer changes specific to SlicerQReads:

```
$ git shortlog d06e71c8a6..0f2d007c19 --no-merges 
Jean-Christophe Fillion-Robin (5):
      [SlicerQReads] BUG: Allow module panel to be resized
      [SlicerQReads] ENH: Invert pan and zoom controls associated viewers
      [SlicerQReads] ENH: Remove irrelevant actions when right-clicking on markups
      [Backport PR-5611] ENH: Add readSettings/writeSetting to qSlicerMainWindow public API
      [Backport PR-5620] COMP: Fix configruation of qSlicerSimpleMarkupsWidgetTest1 with QtTesting OFF
```

List of Slicer changes:

```
$ git shortlog 68b5cd0e1..d06e71c8a6 --no-merges
Alexis Girault (1):
      DOC: Bold Glossary terms to improve readability (PR-5552)

Andras Lasso (81):
      BUG: Fix mouse cursor during markups curve point insertion
      BUG: Show default layout if the scene uses an undefined layout id
      ENH: Display error message if node loading fails
      ENH: Improve module access scripts in slicer.util
      ENH: Performance improvements
      Minor improvements (PR-5449)
      ENH: Move unit and recent log file paths storage to common application settings
      BUG: Ensure temporaryPath is writable (PR-5458)
      ENH: Make slicer.util API documentation more consistent
      DOC: Improve linux build instructions
      Improve dicom export robustness (PR-5467)
      ENH: Update CTK to latest version
      COMP: Fix linux build error
      BUG: Fix scene not updating after toggling subject hierarchy item visibility
      BUG: Fix table view losing table node selection after batch processing (PR-5475)
      DOC: Add note on color image registration
      ENH: Improve default axis-aligned display of single-slice volume
      ENH: Add label display and measurements for ROI and plane markups
      ENH: Make markups measurements use area and volume units
      STYLE: Remove non-ASCII characters
      COMP: Fix build error on macOS
      BUG: Fix reading of csv files that contain backslash characters (PR-5483)
      ENH: Ensure that remote cache folder is writable (PR-5487)
      BUG: Fix display of CPU volume rendering of volumes with small voxel size
      ENH: Add Center volume option and documentation to ACPC Transform module (PR-5492)
      BUG: Fix paint effect drawing extra strokes after interrupted
      DOC: Move markups module developer information to developer guide
      ENH: Add custom volume rendering presets to the top of the preset list by default (PR-5509)
      ENH: Save coordinate system unit to markups json files
      BUG: Fix SegmentationsModuleTest1 error
      BUG: Fix ExecutionModelTourTest
      BUG: Fix blinking of segmentation during segmentation editing
      BUG: Update CompareVolumes and LandmarkRegistration to fix VTK9 incompatibilities
      ENH: Add experimental option for fast 3D picking for moving the crosshair
      BUG: Fix unnecessary restart of Slicer when modifying settings
      BUG: Fix writing of incompatible VTK model files
      BUG: Fix crash when loading tracked image sequence multiple times
      BUG: Make Segment Editor's background volume detection more robust
      COMP: Fix build error with VTK8
      BUG: Fix py_SubjectHierarchyGenericSelfTest
      COMP: Fix remaining build error with VTK8
      ENH: Make default slice view orientations configurable (PR-5536)
      DOC: Add extensions manager documentation
      DOC: Add more information on proxy settings to extensions_manager.md
      BUG: Fix logic that determines if a module is built-in
      DOC: Add SlicerWeb URL to getting_started.md
      ENH: Allow using markups ROI node in Crop volume module
      DOC: Add Glossary of commonly used terms
      BUG: Fix padding voxel value when resampling a segmentation master volume
      DOC: Improve Extensions manager page
      BUG: Fix new segments appearing as hidden
      DOC: Add example error message to extensions_manager.md
      BUG: Make cropping of vector volumes more intuitive (PR-5563)
      DOC: Update registration.md
      ENH: Small fixes 20210405 (PR-5569)
      ENH: Optimize markups batch update speed
      ENH: Use parallel transport for more robust curve coordinate system computation
      BUG: Prevent duplicate paths added to environment variables
      ENH: Added detailed error reporting to mrml file loading
      BUG: Fix crash after deleting a transform that had a 3D widget
      BUG: Restore slice increment/decrement direction in slice views
      ENH: Improve DICOM examine and load performance (PR-5577)
      DOC: Make linux distro specific install instructions more discoverable
      BUG: Fix slice visibility of markups loaded from old scenes
      BUG: Fix markups text-shadow properties reading
      ENH: Save all markups display node properties in markups
      ENH: Improve markups label visibility by enabling bold style and shadows by default
      BUG: Fixed label positions in zoomed in view (PR-5581)
      ENH: Added new color nodes for PET image display: PET-Rainbow2, PET-DICOM, and PET-HotMetalBlue (PR-5587)
      BUG: Fix usage of auto
      COMP: Temporary fix for build error
      ENH: Enable testing of LoadableCustomMarkups module
      STYLE: Remove non-existing "verticalStretch" attribute from view layout description
      ENH: Improve model loading
      ENH: Allow setting array name in ProbeVolumeWithModel module
      ENH: Improve sequence browser toolbar usability
      DOC: Add information to file formats page about RGB support in model files
      DOC: Added description of more supported file formats
      DOC: Add link to documentation to .mkp.json schema
      DOC: Move Script Repository to readthedocs
      DOC: Add example of setting crosshair position

Andrey Fedorov (1):
      ENH: update DCMTK to version 3.6.6

Csaba Pinter (11):
      ENH: Add properties for easy visibility setting of SH tree columns
      ENH: Extend capabilities of subject hierarchy attribute filtering
      ENH: Observe markup measurements to trigger necessary updates
      ENH: Use flow layout in Sample Data module (PR-5530)
      BUG: Restore collapsed state of Advanced section of Markups display widget
      BUG: Fix circular markups measurement update calls
      BUG: Fix SampleData test that failed since last change
      BUG: Fix Segment Editor Undo/Redo button states
      COMP: Fix Windows build error in vtkSlicerMarkupsLogicTest4 (PR-5590)
      ENH: Add set terminology action to markups view menu
      STYLE: Improve naming and order of markup terminology view menu

Dženan Zukić (1):
      ENH: add support for Scanco file format

Fernando Bordignon (1):
      BUG: Fix launcher executable file path in custom application (PR-5531)

James Butler (19):
      COMP: Update SimpleITK to v2.0.2
      ENH: Remove deprecated sitkUtils API
      COMP: Add python packages update script
      COMP: Update python packages to latest
      BUG: Fix missing ITKv5 migration items for MorphologicalContourInterpolator
      COMP: Build itkMorphologicalContourInterpolator as ITK Remote module
      COMP: Turn on compiler warnings for use of ITK Legacy code
      COMP: Update ITK to post-v5.2rc03 with matching SimpleITK and BRAINSTools
      COMP: Update ITK to v5.2.0 and update SimpleITK
      STYLE: Remove unnecessary trailing semicolon in python code
      ENH: Move Pluggable Markups test module to template directory
      ENH: Move testing methods in scripted logic class to test class
      COMP: Update LandmarkRegistration
      ENH: Remove deprecated clickAndDrag from logic base class
      ENH: Support taking screenshot without displaying message
      BUG: Fix qMRMLCollapsibleButton pallete not updating on style change
      BUG: Fix missing markups place button icon
      ENH: Change markups place button icon based on markups node type
      BUG: Fix failing FiducialLayoutSwitchBug1914 test case

Jean-Christophe Fillion-Robin (31):
      DOC: Add "colorNodeID" to "Modules API / Volumes / Reading from file"
      BUG: Update CTKAppLauncher from 0.1.28 to 29 to fix extension loading on macOS
      ENH: Add SlicerMacroBuildScriptedCLI CMake function (PR-5455)
      ENH: Update SlicerMacroBuildScriptedCLI to display comment only if needed
      DOC: Fix comment in SlicerMacroBuildModuleLogic
      BUG: Fix python wrapping of vtkSlicerCLIModuleLogic using VTK9
      ENH: Update make-ca.sh script to strip trailing whitespaces
      ENH: Update Slicer.crt CA bundle
      ENH: Slicer 4.11.20210226
      ENH: Resume 4.13.0 development
      BUG: Fix linux package ensuring OpenGL_GL_PREFERENCE is considered with VTK9 (PR-5501)
      ENH: Update slicerMacroBuildApplication adding SPLASHSCREEN_ENABLED option (PR-5488)
      COMP: Fix qMRMLMarkupsROIWidget build error against Qt 5.10
      STYLE: Remove debug message from VolumeRendering CMakeLists
      BUG: Ensure VTK rendering object factory overrides are registered
      BUG: Update VTK to fix crash and avoid process output polluting by debug leaks
      COMP: Ensure all vtk python modules are fixed up on macOS
      BUG: Fix import of python modules on Linux selectively stripping libraries
      STYLE: Remove obsolete "PythonModule" support from vtkSlicerCLIModuleLogic
      COMP: Fix -Wunused-but-set-variable in vtkMRMLMeasurementAngle
      STYLE: Refactor and simplify vtkMRMLMeasurementAngle::Compute() to exit early
      COMP: Fix -Wunused-variable in vtkSlicerROIRepresentation3D
      COMP: Fix -Wunused-variable in vtkSlicerROIWidget
      COMP: Fix -Wunused-variable in qSlicerSubjectHierarchyVolumesPlugin
      COMP: Fix -Wsign-compare in vtkSlicerMarkupsLogic
      COMP: Fix -Wparentheses in vtkCurveMeasurementsCalculator
      COMP: Fix -Wunused-parameter in vtkSlicerApplicationLogic
      DOC: Update "Commercial Use" section to fix case
      DOC: Update Kitware commercial partner description
      BUG: Update MultiVolumeImporter/MultiVolumeExplorer to support VTK9
      BUG: Fix closeTemporaryDatabase to re-open original database only if it exists

Kerim (2):
      COMP: Undefined class "QTemporaryFile" when building using SlicerCAT
      COMP: Update code to allow both C++11 and C++17 compilation

Kyle Sunderland (15):
      BUG: Fix segment subject hierarchy visibility when display node modified
      ENH: Add Markups ROI node
      BUG: Fix vtkMRMLVolumeRenderingDisplayableManagerTest1
      ENH: Miscellaneous ROI display improvements
      ENH: Improve markup ROI interaction
      BUG: Fix MainWindow.statusBar() calls in util.py
      BUG: Fix default storage node creation in LoadMarkupsFromJson
      ENH: Add Alt shortcut for changing ROI size without moving center
      ENH: Add separate node attributes for interaction handle visibility
      ENH: Hide markup line in 3D view if the number of control points != 2
      BUG: Fix mouse flicker when hovering over interaction handles
      ENH: Improve Markups Plane and ROI interaction
      ENH: Add Markups ROI GetRASBounds and GetBounds functions
      ENH: Hide markups in slice views when they do not intersect the slice
      ENH: Apply hardened transforms to Markups ROI

Mikhail Polkovnikov (2):
      ENH: DICOM plugins layout is placed into a scroll area widget (PR-5484)
      ENH: DICOM plugins layout is moved from browser to module panel

Nathan Beaumont (1):
      ENH: Scalar Volume Statistics has method for getting stencil

Pablo Hernandez-Cerdan (1):
      BUG: Fix 'fabs' was not declared

Rafael Palomar (12):
      BUG: Enabling builtin ctypes in python (PR-5346)
      COMP: Replace deprecated qSort by std::sort (PR-5557)
      ENH: Reorganize Markups icons
      ENH: Add pluggable markups architecture
      STYLE: Using const Qstring& on qSlicerSimpleMarkupsWidget
      ENH: Bring markups naming consistency (PR-5196)
      STYLE: Rename qMRMLMarkupsROIWidget
      STYLE: Fix indenting in various markups files
      ENH: Add unit tests for pluggable markups logic
      ENH: Add unit tests for markups factory
      ENH: Add Pluggable Markups testing loadable module
      ENH: Add Pluggable Markups python self test

Steve Pieper (1):
      BUG: fix tmp file path calculation (PR-5463)

Theodore Aptekarev (1):
      DOC: Update macOS build instructions

Thibault Pelletier (1):
      ENH: Improve segmentation erase effect performance
```