### PR TITLE
BUG: Fix toggling of SlabThickness mode

### DIFF
--- a/Modules/Scripted/QReads/QReads.py
+++ b/Modules/Scripted/QReads/QReads.py
@@ -237,11 +237,11 @@ class QReadsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     node = calldata
     if not isinstance(node, slicer.vtkMRMLScalarVolumeNode):
       return
-    self.updateParameterNodeFromVolumeNode(node)
 
     def _update():
       slicer.app.processEvents()
       slicer.app.layoutManager().resetThreeDViews()
+      self.updateParameterNodeFromVolumeNode(node)
       QReadsLogic.setZoom(self._parameterNode.GetParameter("Zoom"))
 
       # Dictionary of name and values


### PR DESCRIPTION
This commit calls "updateParameterNodeFromVolumeNode" with delay. This
ensures the function "DICOMScalarVolumePluginClass::loadFilesWithSeriesReader"
is called after (1) the node is added to the scene and (2) the function
vtkMRMLVolumeNode::SetRASToIJKMatrix has been called and the "Spacing"
properly initialized.

Fixes #103